### PR TITLE
increase height of preview canvas image in demo

### DIFF
--- a/demo/script.js
+++ b/demo/script.js
@@ -203,7 +203,7 @@ function draw_curve() {
   }
 
   two.width = W*info.S.x*1.1;
-  two.height = H*info.S.y*1.1;
+  two.height = H*info.S.y*2;
 
   two.update();
   two.render();


### PR DESCRIPTION
* small sized curves get cutoff (e.g. 3x3) because the window scaling factor is only 1.1 and the margins are significant at small scales. Increasing the height factor to 2 (from 1.1) alleviates the problem while minimizing the risk of the canvas spilling over horizontally.