### PR TITLE
resolves #11

### DIFF
--- a/demo/script.js
+++ b/demo/script.js
@@ -203,7 +203,7 @@ function draw_curve() {
   }
 
   two.width = W*info.S.x*1.1;
-  two.height = H*info.S.y*1.1;
+  two.height = H*info.S.y*2;
 
   two.update();
   two.render();

--- a/ports/gilbert.c
+++ b/ports/gilbert.c
@@ -175,17 +175,12 @@ int gilbert_d2xy_r(int dst_idx, int cur_idx,
                    int *xres, int *yres,
                    int ax,int ay,
                    int bx,int by ) {
-  static int max_iter = 0;
-
   int nxt_idx;
   int w, h, x, y,
       dax, day,
       dbx, dby,
       di;
   int ax2, ay2, bx2, by2, w2, h2;
-
-  if (max_iter > 100000) { return -1; }
-  max_iter++;
 
   w = abs(ax + ay);
   h = abs(bx + by);
@@ -891,7 +886,7 @@ int main(int argc, char **argv) {
   }
 
   strncpy(buf, argv[1], 1023);
-  buf[1024]='\0';
+  buf[1023]='\0';
 
   w = atoi(argv[2]);
   h = atoi(argv[3]);

--- a/tests/runtests.sh
+++ b/tests/runtests.sh
@@ -159,3 +159,6 @@ gilbert_cmp2 $x $y
 x=7 ; y=6 ; z=4
 gilbert_cmp3 $x $y $z
 
+x=490 ; y=490
+gilbert_cmp2 $x $y
+


### PR DESCRIPTION
 * vestigial test code that caused `gilbert_d2xy(&x, &y, 7861, 490, 490)` to incorrectly return
  -1 (there was a `max_iter` check to return after some hard coded value)
* added test to make sure at least that condition is tested for
* `gilbert.c` had buffer overrun setting last byte of `buf`, correctly sets `buf[1023]='\0'`
  instead of `buf[1024]`
